### PR TITLE
Add generic imageOverlay slot for per-slide overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Usage example:
 ```
 
 #### imageOverlay
-Content rendered on top of the currently displayed image, aligned exactly to the rendered image box (not the surrounding viewport). Only rendered for image-type media, never for video or YouTube slides. The overlay layer has `pointer-events: none` by default so it never interferes with swipe/click navigation; re-enable pointer events per element inside the slot if needed. Useful for drawing annotations (arrows, highlight boxes) over a photo.
+Content rendered on top of the currently displayed image, sized and positioned to match the image box, not the surrounding viewport. Only shows up for image slides; video and YouTube slides skip it. Pointer events are off on the overlay by default so it doesn't block swipe or click navigation — turn them back on for individual elements in the slot if you need something in there to be clickable. Handy for drawing arrows or highlight boxes over a photo.
 
 ##### Slot props
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,29 @@ Usage example:
 </LightBox>
 ```
 
+#### imageOverlay
+Content rendered on top of the currently displayed image, aligned exactly to the rendered image box (not the surrounding viewport). Only rendered for image-type media, never for video or YouTube slides. The overlay layer has `pointer-events: none` by default so it never interferes with swipe/click navigation; re-enable pointer events per element inside the slot if needed. Useful for drawing annotations (arrows, highlight boxes) over a photo.
+
+##### Slot props
+
+| name | type | description |
+|------|------|-------------|
+| currentMedia | Object | The currently displayed object from the media array |
+| index | integer | The index of the currently displayed media item |
+
+Usage example:
+
+```javascript
+<LightBox
+  ref="overlayLightbox"
+  :media="media"
+>
+  <template v-slot:imageOverlay="{ currentMedia }">
+    <MyAnnotationsOverlay :annotations="currentMedia.annotations" />
+  </template>
+</LightBox>
+```
+
 #### videoIcon
 The Icon used for videos
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-it-bigger",
   "description": "A simple image / (YouTube) video lightbox component for Vue.js.",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "author": "Janos Rusiczki <janos.rusiczki@gmail.com>",
   "license": "MIT",
   "type": "module",

--- a/specs/LightBox/props-and-events.spec.js
+++ b/specs/LightBox/props-and-events.spec.js
@@ -1,511 +1,610 @@
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
-import LightBox from '@/LightBox.vue'
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import LightBox from "@/LightBox.vue";
 
 import {
   mediaWithOneImageWithoutType,
   mediaWithNineImages,
   mediaWithTwoImages,
   mediaWithCaption,
-  mediaWithOneVideoWithoutAutoplay
-} from '../fixtures'
+  mediaWithOneVideoWithoutAutoplay,
+} from "../fixtures";
 
-describe('LightBox - Props and Events', () => {
-  let wrapper
+describe("LightBox - Props and Events", () => {
+  let wrapper;
 
   afterEach(() => {
     if (wrapper) {
-      wrapper.unmount()
+      wrapper.unmount();
     }
-    document.querySelector('html').classList.remove('no-scroll')
-    document.querySelector('body').classList.remove('vib-open')
-    vi.restoreAllMocks()
-  })
+    document.querySelector("html").classList.remove("no-scroll");
+    document.querySelector("body").classList.remove("vib-open");
+    vi.restoreAllMocks();
+  });
 
-  describe('showLightBox prop', () => {
-    test('showLightBox: false starts with container hidden', () => {
+  describe("showLightBox prop", () => {
+    test("showLightBox: false starts with container hidden", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithOneImageWithoutType,
-          showLightBox: false
-        }
-      })
+          showLightBox: false,
+        },
+      });
 
-      expect(wrapper.find('.vib-container').element.style.display).toBe('none')
-    })
+      expect(wrapper.find(".vib-container").element.style.display).toBe("none");
+    });
 
-    test('showLightBox: true starts with container visible', () => {
+    test("showLightBox: true starts with container visible", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithOneImageWithoutType,
-          showLightBox: true
-        }
-      })
+          showLightBox: true,
+        },
+      });
 
-      expect(wrapper.find('.vib-container').element.style.display).not.toBe('none')
-    })
-  })
+      expect(wrapper.find(".vib-container").element.style.display).not.toBe(
+        "none",
+      );
+    });
+  });
 
-  describe('startAt prop', () => {
+  describe("startAt prop", () => {
     beforeEach(() => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithNineImages,
-          startAt: 3
-        }
-      })
-    })
+          startAt: 3,
+        },
+      });
+    });
 
-    test('startAt: 3 starts at the fourth image', () => {
-      expect(wrapper.find('img.vib-image').attributes('src')).toBe(mediaWithNineImages[3].src)
-    })
+    test("startAt: 3 starts at the fourth image", () => {
+      expect(wrapper.find("img.vib-image").attributes("src")).toBe(
+        mediaWithNineImages[3].src,
+      );
+    });
 
-    test('footer shows correct position for startAt', () => {
-      expect(wrapper.find('.vib-footer-count').text()).toContain('4 / 9')
-    })
-  })
+    test("footer shows correct position for startAt", () => {
+      expect(wrapper.find(".vib-footer-count").text()).toContain("4 / 9");
+    });
+  });
 
-  describe('disableScroll prop', () => {
-    test('disableScroll: true (default) adds no-scroll to html on open', () => {
+  describe("disableScroll prop", () => {
+    test("disableScroll: true (default) adds no-scroll to html on open", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithOneImageWithoutType,
-          disableScroll: true
-        }
-      })
+          disableScroll: true,
+        },
+      });
 
-      expect(document.querySelector('html').classList.contains('no-scroll')).toBe(true)
-    })
+      expect(
+        document.querySelector("html").classList.contains("no-scroll"),
+      ).toBe(true);
+    });
 
-    test('disableScroll: false does not add no-scroll to html', () => {
+    test("disableScroll: false does not add no-scroll to html", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithOneImageWithoutType,
-          disableScroll: false
-        }
-      })
+          disableScroll: false,
+        },
+      });
 
-      expect(document.querySelector('html').classList.contains('no-scroll')).toBe(false)
-    })
+      expect(
+        document.querySelector("html").classList.contains("no-scroll"),
+      ).toBe(false);
+    });
 
-    test('disableScroll: true removes no-scroll on close', async () => {
+    test("disableScroll: true removes no-scroll on close", async () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithOneImageWithoutType,
-          disableScroll: true
-        }
-      })
+          disableScroll: true,
+        },
+      });
 
-      expect(document.querySelector('html').classList.contains('no-scroll')).toBe(true)
+      expect(
+        document.querySelector("html").classList.contains("no-scroll"),
+      ).toBe(true);
 
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
-      await wrapper.vm.$nextTick()
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      await wrapper.vm.$nextTick();
 
-      expect(document.querySelector('html').classList.contains('no-scroll')).toBe(false)
-    })
+      expect(
+        document.querySelector("html").classList.contains("no-scroll"),
+      ).toBe(false);
+    });
 
-    test('disableScroll: false does not modify no-scroll class on close', async () => {
+    test("disableScroll: false does not modify no-scroll class on close", async () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithOneImageWithoutType,
-          disableScroll: false
-        }
-      })
+          disableScroll: false,
+        },
+      });
 
       // Manually add no-scroll to test that it's NOT removed when disableScroll is false
-      document.querySelector('html').classList.add('no-scroll')
+      document.querySelector("html").classList.add("no-scroll");
 
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
-      await wrapper.vm.$nextTick()
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      await wrapper.vm.$nextTick();
 
       // Should NOT have removed it because disableScroll is false
       // The component only manages no-scroll when disableScroll is true
-      expect(document.querySelector('html').classList.contains('no-scroll')).toBe(true)
+      expect(
+        document.querySelector("html").classList.contains("no-scroll"),
+      ).toBe(true);
 
       // Clean up
-      document.querySelector('html').classList.remove('no-scroll')
-    })
-  })
+      document.querySelector("html").classList.remove("no-scroll");
+    });
+  });
 
-  describe('showThumbs prop', () => {
-    test('showThumbs: true (default) renders thumbnail wrapper', () => {
+  describe("showThumbs prop", () => {
+    test("showThumbs: true (default) renders thumbnail wrapper", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithOneImageWithoutType,
-          showThumbs: true
-        }
-      })
+          showThumbs: true,
+        },
+      });
 
-      expect(wrapper.find('.vib-thumbnail-wrapper').exists()).toBe(true)
-    })
+      expect(wrapper.find(".vib-thumbnail-wrapper").exists()).toBe(true);
+    });
 
-    test('showThumbs: false hides thumbnail wrapper', () => {
+    test("showThumbs: false hides thumbnail wrapper", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithOneImageWithoutType,
-          showThumbs: false
-        }
-      })
+          showThumbs: false,
+        },
+      });
 
-      expect(wrapper.find('.vib-thumbnail-wrapper').exists()).toBe(false)
-    })
-  })
+      expect(wrapper.find(".vib-thumbnail-wrapper").exists()).toBe(false);
+    });
+  });
 
-  describe('showCaption prop', () => {
-    test('showCaption: false (default) hides the caption', () => {
+  describe("showCaption prop", () => {
+    test("showCaption: false (default) hides the caption", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithCaption,
-          showCaption: false
-        }
-      })
+          showCaption: false,
+        },
+      });
 
       // The caption div is inside the customCaption slot default content
-      const captionDivs = wrapper.findAll('.vib-footer div')
-      const captionDiv = captionDivs.find(div => div.html().includes('v-show'))
+      const captionDivs = wrapper.findAll(".vib-footer div");
+      const captionDiv = captionDivs.find((div) =>
+        div.html().includes("v-show"),
+      );
       if (captionDiv) {
-        expect(captionDiv.element.style.display).toBe('none')
+        expect(captionDiv.element.style.display).toBe("none");
       }
-    })
+    });
 
-    test('showCaption: true displays caption HTML', () => {
+    test("showCaption: true displays caption HTML", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithCaption,
-          showCaption: true
-        }
-      })
+          showCaption: true,
+        },
+      });
 
-      const footerHTML = wrapper.find('.vib-footer').html()
-      expect(footerHTML).toContain('<strong>Bold caption</strong>')
-    })
-  })
+      const footerHTML = wrapper.find(".vib-footer").html();
+      expect(footerHTML).toContain("<strong>Bold caption</strong>");
+    });
+  });
 
-  describe('nThumbs prop', () => {
-    test('nThumbs: 3 displays only 3 thumbnails', () => {
+  describe("nThumbs prop", () => {
+    test("nThumbs: 3 displays only 3 thumbnails", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithNineImages,
-          nThumbs: 3
-        }
-      })
+          nThumbs: 3,
+        },
+      });
 
-      const visibleThumbs = wrapper.findAll('.vib-thumbnail-wrapper > div:not([style*="display: none"])')
-      expect(visibleThumbs.length).toBe(3)
-    })
-  })
+      const visibleThumbs = wrapper.findAll(
+        '.vib-thumbnail-wrapper > div:not([style*="display: none"])',
+      );
+      expect(visibleThumbs.length).toBe(3);
+    });
+  });
 
-  describe('closable prop', () => {
-    test('closable: true (default) renders close button', () => {
+  describe("closable prop", () => {
+    test("closable: true (default) renders close button", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithOneImageWithoutType,
-          closable: true
-        }
-      })
+          closable: true,
+        },
+      });
 
-      expect(wrapper.find('.vib-close').exists()).toBe(true)
-    })
+      expect(wrapper.find(".vib-close").exists()).toBe(true);
+    });
 
-    test('closable: false does not render close button', () => {
+    test("closable: false does not render close button", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithOneImageWithoutType,
-          closable: false
-        }
-      })
+          closable: false,
+        },
+      });
 
-      expect(wrapper.find('.vib-close').exists()).toBe(false)
-    })
-  })
+      expect(wrapper.find(".vib-close").exists()).toBe(false);
+    });
+  });
 
-  describe('custom text props', () => {
-    test('closeText sets close button title', () => {
+  describe("custom text props", () => {
+    test("closeText sets close button title", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithOneImageWithoutType,
-          closeText: 'Dismiss'
-        }
-      })
+          closeText: "Dismiss",
+        },
+      });
 
-      expect(wrapper.find('.vib-close').attributes('title')).toBe('Dismiss')
-    })
+      expect(wrapper.find(".vib-close").attributes("title")).toBe("Dismiss");
+    });
 
-    test('previousText sets left arrow title', () => {
+    test("previousText sets left arrow title", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithTwoImages,
-          previousText: 'Back'
-        }
-      })
+          previousText: "Back",
+        },
+      });
 
-      expect(wrapper.find('.vib-arrow-left').attributes('title')).toBe('Back')
-    })
+      expect(wrapper.find(".vib-arrow-left").attributes("title")).toBe("Back");
+    });
 
-    test('nextText sets right arrow title', () => {
+    test("nextText sets right arrow title", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithTwoImages,
-          nextText: 'Forward'
-        }
-      })
+          nextText: "Forward",
+        },
+      });
 
-      expect(wrapper.find('.vib-arrow-right').attributes('title')).toBe('Forward')
-    })
+      expect(wrapper.find(".vib-arrow-right").attributes("title")).toBe(
+        "Forward",
+      );
+    });
 
-    test('default text values', () => {
+    test("default text values", () => {
       wrapper = mount(LightBox, {
         props: {
-          media: mediaWithTwoImages
-        }
-      })
+          media: mediaWithTwoImages,
+        },
+      });
 
-      expect(wrapper.find('.vib-close').attributes('title')).toBe('Close (Esc)')
-      expect(wrapper.find('.vib-arrow-left').attributes('title')).toBe('Previous')
-      expect(wrapper.find('.vib-arrow-right').attributes('title')).toBe('Next')
-    })
-  })
+      expect(wrapper.find(".vib-close").attributes("title")).toBe(
+        "Close (Esc)",
+      );
+      expect(wrapper.find(".vib-arrow-left").attributes("title")).toBe(
+        "Previous",
+      );
+      expect(wrapper.find(".vib-arrow-right").attributes("title")).toBe("Next");
+    });
+  });
 
-  describe('lengthToLoadMore and onLoad event', () => {
-    test('emits onLoad when navigating near the end', async () => {
+  describe("lengthToLoadMore and onLoad event", () => {
+    test("emits onLoad when navigating near the end", async () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithNineImages,
-          lengthToLoadMore: 2
-        }
-      })
+          lengthToLoadMore: 2,
+        },
+      });
 
       // Navigate to index 6 (>= 9 - 2 - 1 = 6)
       for (let i = 0; i < 6; i++) {
-        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "ArrowRight" }),
+        );
       }
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      expect(wrapper.emitted('onLoad')).toBeTruthy()
-    })
+      expect(wrapper.emitted("onLoad")).toBeTruthy();
+    });
 
-    test('does not emit onLoad when not near end', async () => {
+    test("does not emit onLoad when not near end", async () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithNineImages,
-          lengthToLoadMore: 2
-        }
-      })
+          lengthToLoadMore: 2,
+        },
+      });
 
       // Navigate to index 3
       for (let i = 0; i < 3; i++) {
-        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "ArrowRight" }),
+        );
       }
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      expect(wrapper.emitted('onLoad')).toBeFalsy()
-    })
+      expect(wrapper.emitted("onLoad")).toBeFalsy();
+    });
 
-    test('emits onLoad when lengthToLoadMore is 0 and at last image', async () => {
+    test("emits onLoad when lengthToLoadMore is 0 and at last image", async () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithNineImages,
-          lengthToLoadMore: 0
-        }
-      })
+          lengthToLoadMore: 0,
+        },
+      });
 
       // Navigate to last image (>= 9 - 0 - 1 = 8)
       for (let i = 0; i < 8; i++) {
-        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "ArrowRight" }),
+        );
       }
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      expect(wrapper.emitted('onLoad')).toBeTruthy()
-    })
-  })
+      expect(wrapper.emitted("onLoad")).toBeTruthy();
+    });
+  });
 
-  describe('event emissions', () => {
+  describe("event emissions", () => {
     beforeEach(() => {
-      wrapper = mount(LightBox, {
-        props: {
-          media: mediaWithNineImages
-        }
-      })
-    })
-
-    test('emits onOpened when lightbox opens', () => {
-      expect(wrapper.emitted('onOpened')).toBeTruthy()
-    })
-
-    test('emits onClosed when lightbox closes', async () => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.emitted('onClosed')).toBeTruthy()
-    })
-
-    test('emits onImageChanged when navigating', async () => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.emitted('onImageChanged')).toBeTruthy()
-      expect(wrapper.emitted('onImageChanged')[0]).toEqual([1])
-    })
-
-    test('emits onFirstIndex when navigating to first image', async () => {
-      // Navigate away first
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
-      await wrapper.vm.$nextTick()
-
-      // Navigate back to index 0
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.emitted('onFirstIndex')).toBeTruthy()
-    })
-
-    test('emits onLastIndex when reaching last image', async () => {
-      // Navigate to last image (index 8)
-      for (let i = 0; i < 8; i++) {
-        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
-      }
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.emitted('onLastIndex')).toBeTruthy()
-    })
-
-    test('emits onStartIndex when returning to startAt', async () => {
-      wrapper.unmount()
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithNineImages,
-          startAt: 3
-        }
-      })
+        },
+      });
+    });
+
+    test("emits onOpened when lightbox opens", () => {
+      expect(wrapper.emitted("onOpened")).toBeTruthy();
+    });
+
+    test("emits onClosed when lightbox closes", async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted("onClosed")).toBeTruthy();
+    });
+
+    test("emits onImageChanged when navigating", async () => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight" }),
+      );
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted("onImageChanged")).toBeTruthy();
+      expect(wrapper.emitted("onImageChanged")[0]).toEqual([1]);
+    });
+
+    test("emits onFirstIndex when navigating to first image", async () => {
+      // Navigate away first
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight" }),
+      );
+      await wrapper.vm.$nextTick();
+
+      // Navigate back to index 0
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft" }),
+      );
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted("onFirstIndex")).toBeTruthy();
+    });
+
+    test("emits onLastIndex when reaching last image", async () => {
+      // Navigate to last image (index 8)
+      for (let i = 0; i < 8; i++) {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "ArrowRight" }),
+        );
+      }
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted("onLastIndex")).toBeTruthy();
+    });
+
+    test("emits onStartIndex when returning to startAt", async () => {
+      wrapper.unmount();
+      wrapper = mount(LightBox, {
+        props: {
+          media: mediaWithNineImages,
+          startAt: 3,
+        },
+      });
 
       // Navigate away from startAt
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
-      await wrapper.vm.$nextTick()
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight" }),
+      );
+      await wrapper.vm.$nextTick();
 
       // Navigate back to index 3
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
-      await wrapper.vm.$nextTick()
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft" }),
+      );
+      await wrapper.vm.$nextTick();
 
-      expect(wrapper.emitted('onStartIndex')).toBeTruthy()
-    })
-  })
+      expect(wrapper.emitted("onStartIndex")).toBeTruthy();
+    });
+  });
 
-  describe('DOM class management', () => {
+  describe("DOM class management", () => {
     beforeEach(() => {
       wrapper = mount(LightBox, {
         props: {
-          media: mediaWithOneImageWithoutType
-        }
-      })
-    })
+          media: mediaWithOneImageWithoutType,
+        },
+      });
+    });
 
-    test('adds vib-open to body when opened', () => {
-      expect(document.querySelector('body').classList.contains('vib-open')).toBe(true)
-    })
+    test("adds vib-open to body when opened", () => {
+      expect(
+        document.querySelector("body").classList.contains("vib-open"),
+      ).toBe(true);
+    });
 
-    test('removes vib-open from body when closed', async () => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
-      await wrapper.vm.$nextTick()
+    test("removes vib-open from body when closed", async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      await wrapper.vm.$nextTick();
 
-      expect(document.querySelector('body').classList.contains('vib-open')).toBe(false)
-    })
+      expect(
+        document.querySelector("body").classList.contains("vib-open"),
+      ).toBe(false);
+    });
 
-    test('adds no-scroll to html when opened (disableScroll: true)', () => {
-      expect(document.querySelector('html').classList.contains('no-scroll')).toBe(true)
-    })
+    test("adds no-scroll to html when opened (disableScroll: true)", () => {
+      expect(
+        document.querySelector("html").classList.contains("no-scroll"),
+      ).toBe(true);
+    });
 
-    test('removes no-scroll from html when closed', async () => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
-      await wrapper.vm.$nextTick()
+    test("removes no-scroll from html when closed", async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      await wrapper.vm.$nextTick();
 
-      expect(document.querySelector('html').classList.contains('no-scroll')).toBe(false)
-    })
-  })
+      expect(
+        document.querySelector("html").classList.contains("no-scroll"),
+      ).toBe(false);
+    });
+  });
 
-  describe('slot rendering', () => {
-    test('close slot replaces default close icon', () => {
+  describe("slot rendering", () => {
+    test("close slot replaces default close icon", () => {
       wrapper = mount(LightBox, {
         props: {
-          media: mediaWithOneImageWithoutType
+          media: mediaWithOneImageWithoutType,
         },
         slots: {
-          close: '<span class="custom-close">X</span>'
-        }
-      })
+          close: '<span class="custom-close">X</span>',
+        },
+      });
 
-      expect(wrapper.find('.custom-close').exists()).toBe(true)
-      expect(wrapper.find('.custom-close').text()).toBe('X')
-    })
+      expect(wrapper.find(".custom-close").exists()).toBe(true);
+      expect(wrapper.find(".custom-close").text()).toBe("X");
+    });
 
-    test('previous slot replaces default left arrow', () => {
+    test("previous slot replaces default left arrow", () => {
       wrapper = mount(LightBox, {
         props: {
-          media: mediaWithTwoImages
+          media: mediaWithTwoImages,
         },
         slots: {
-          previous: '<span class="custom-prev">Prev</span>'
-        }
-      })
+          previous: '<span class="custom-prev">Prev</span>',
+        },
+      });
 
-      expect(wrapper.find('.custom-prev').exists()).toBe(true)
-      expect(wrapper.find('.custom-prev').text()).toBe('Prev')
-    })
+      expect(wrapper.find(".custom-prev").exists()).toBe(true);
+      expect(wrapper.find(".custom-prev").text()).toBe("Prev");
+    });
 
-    test('next slot replaces default right arrow', () => {
+    test("next slot replaces default right arrow", () => {
       wrapper = mount(LightBox, {
         props: {
-          media: mediaWithTwoImages
+          media: mediaWithTwoImages,
         },
         slots: {
-          next: '<span class="custom-next">Next</span>'
-        }
-      })
+          next: '<span class="custom-next">Next</span>',
+        },
+      });
 
-      expect(wrapper.find('.custom-next').exists()).toBe(true)
-      expect(wrapper.find('.custom-next').text()).toBe('Next')
-    })
+      expect(wrapper.find(".custom-next").exists()).toBe(true);
+      expect(wrapper.find(".custom-next").text()).toBe("Next");
+    });
 
-    test('videoIcon slot replaces default video icon', () => {
+    test("videoIcon slot replaces default video icon", () => {
       wrapper = mount(LightBox, {
         props: {
-          media: mediaWithOneVideoWithoutAutoplay
+          media: mediaWithOneVideoWithoutAutoplay,
         },
         slots: {
-          videoIcon: '<span class="custom-video-icon">Play</span>'
-        }
-      })
+          videoIcon: '<span class="custom-video-icon">Play</span>',
+        },
+      });
 
-      expect(wrapper.find('.custom-video-icon').exists()).toBe(true)
-      expect(wrapper.find('.custom-video-icon').text()).toBe('Play')
-    })
+      expect(wrapper.find(".custom-video-icon").exists()).toBe(true);
+      expect(wrapper.find(".custom-video-icon").text()).toBe("Play");
+    });
 
-    test('customCaption slot replaces default caption', () => {
+    test("customCaption slot replaces default caption", () => {
       wrapper = mount(LightBox, {
         props: {
           media: mediaWithCaption,
-          showCaption: true
+          showCaption: true,
         },
         slots: {
-          customCaption: '<div class="custom-caption">Custom Caption</div>'
-        }
-      })
+          customCaption: '<div class="custom-caption">Custom Caption</div>',
+        },
+      });
 
-      expect(wrapper.find('.custom-caption').exists()).toBe(true)
-      expect(wrapper.find('.custom-caption').text()).toBe('Custom Caption')
-    })
+      expect(wrapper.find(".custom-caption").exists()).toBe(true);
+      expect(wrapper.find(".custom-caption").text()).toBe("Custom Caption");
+    });
 
-    test('footer slot replaces default counter', () => {
+    test("footer slot replaces default counter", () => {
       wrapper = mount(LightBox, {
         props: {
-          media: mediaWithNineImages
+          media: mediaWithNineImages,
         },
         slots: {
-          footer: '<span class="custom-footer">Custom Footer</span>'
-        }
-      })
+          footer: '<span class="custom-footer">Custom Footer</span>',
+        },
+      });
 
-      expect(wrapper.find('.custom-footer').exists()).toBe(true)
-      expect(wrapper.find('.custom-footer').text()).toBe('Custom Footer')
-    })
-  })
-})
+      expect(wrapper.find(".custom-footer").exists()).toBe(true);
+      expect(wrapper.find(".custom-footer").text()).toBe("Custom Footer");
+    });
+
+    test("imageOverlay slot renders over the current image", () => {
+      wrapper = mount(LightBox, {
+        props: {
+          media: mediaWithOneImageWithoutType,
+        },
+        slots: {
+          imageOverlay: '<span class="custom-overlay">Overlay</span>',
+        },
+      });
+
+      const overlay = wrapper.find(
+        ".vib-image-container .vib-image-overlay .custom-overlay",
+      );
+      expect(overlay.exists()).toBe(true);
+      expect(overlay.text()).toBe("Overlay");
+    });
+
+    test("imageOverlay slot exposes currentMedia", () => {
+      wrapper = mount(LightBox, {
+        props: {
+          media: mediaWithCaption,
+        },
+        slots: {
+          imageOverlay: `
+            <template #imageOverlay="{ currentMedia }">
+              <span class="overlay-caption">{{ currentMedia.caption }}</span>
+            </template>
+          `,
+        },
+      });
+
+      expect(wrapper.find(".overlay-caption").text()).toBe(
+        mediaWithCaption[0].caption,
+      );
+    });
+
+    test("imageOverlay slot is not rendered for video media", () => {
+      wrapper = mount(LightBox, {
+        props: {
+          media: mediaWithOneVideoWithoutAutoplay,
+        },
+        slots: {
+          imageOverlay: '<span class="custom-overlay">Overlay</span>',
+        },
+      });
+
+      expect(wrapper.find(".custom-overlay").exists()).toBe(false);
+    });
+  });
+});

--- a/src/components/LightBox.vue
+++ b/src/components/LightBox.vue
@@ -17,21 +17,29 @@
         @touchstart="handleTouchStart"
         @touchend="handleTouchEnd"
       >
-        <div
-          class="vib-content"
-          @click.stop
-        >
-          <transition
-            :name="imageTransitionName"
-          >
-            <img
-              v-if="currentMedia.type == undefined || currentMedia.type == 'image'"
+        <div class="vib-content" @click.stop>
+          <transition :name="imageTransitionName">
+            <div
+              v-if="
+                currentMedia.type == undefined || currentMedia.type == 'image'
+              "
               :key="currentMedia.src"
-              :src="currentMedia.src"
-              :srcset="currentMedia.srcset || ''"
-              class="vib-image"
-              :alt="currentMedia.caption"
+              class="vib-image-container"
             >
+              <img
+                :src="currentMedia.src"
+                :srcset="currentMedia.srcset || ''"
+                class="vib-image"
+                :alt="currentMedia.caption"
+              />
+              <div class="vib-image-overlay">
+                <slot
+                  name="imageOverlay"
+                  :current-media="currentMedia"
+                  :index="select"
+                />
+              </div>
+            </div>
             <video
               v-else-if="currentMedia.type == 'video'"
               :key="currentMedia.sources[0].src"
@@ -46,28 +54,30 @@
                 :key="source.src"
                 :src="source.src"
                 :type="source.type"
-              >
+              />
             </video>
           </transition>
-        </div> <!-- .vib-content -->
+        </div>
+        <!-- .vib-content -->
 
         <!-- Persistent YouTube iframes - outside transition to preserve playback state -->
-        <template
-          v-for="(item, index) in media"
-          :key="'youtube-' + index"
-        >
+        <template v-for="(item, index) in media" :key="'youtube-' + index">
           <transition :name="imageTransitionName">
             <div
               v-if="item.type === 'youtube' && visitedYoutubeIndices.has(index)"
               v-show="select === index"
               class="vib-content"
-              style="position: absolute;"
+              style="position: absolute"
               @click.stop
             >
               <div class="video-background">
                 <iframe
                   :id="'youtube-player-' + index"
-                  :src="'https://www.youtube.com/embed/' + item.id + '?enablejsapi=1&showinfo=0'"
+                  :src="
+                    'https://www.youtube.com/embed/' +
+                    item.id +
+                    '?enablejsapi=1&showinfo=0'
+                  "
                   width="560"
                   height="315"
                   frameborder="0"
@@ -89,7 +99,9 @@
           <div
             v-for="(image, index) in imagesThumb"
             v-show="index >= thumbIndex.begin && index <= thumbIndex.end"
-            :key="typeof image.thumb === 'string' ? `${image.thumb}${index}` : index"
+            :key="
+              typeof image.thumb === 'string' ? `${image.thumb}${index}` : index
+            "
             :style="{ backgroundImage: 'url(' + image.thumb + ')' }"
             :class="'vib-thumbnail' + (select === index ? '-active' : '')"
             @click.stop="showImage(index)"
@@ -101,7 +113,8 @@
               <VideoIcon />
             </slot>
           </div>
-        </div> <!-- .vib-thumbnail-wrapper -->
+        </div>
+        <!-- .vib-thumbnail-wrapper -->
 
         <div
           class="vib-footer vib-hideable"
@@ -109,22 +122,12 @@
           @mouseover="interfaceHovered = true"
           @mouseleave="interfaceHovered = false"
         >
-          <slot
-            name="customCaption"
-            :current-media="currentMedia"
-          >
-            <div
-              v-show="showCaption"
-              v-html="currentMedia.caption"
-            />
+          <slot name="customCaption" :current-media="currentMedia">
+            <div v-show="showCaption" v-html="currentMedia.caption" />
           </slot>
 
           <div class="vib-footer-count">
-            <slot
-              name="footer"
-              :current="select + 1"
-              :total="media.length"
-            >
+            <slot name="footer" :current="select + 1" :total="media.length">
               {{ select + 1 }} / {{ media.length }}
             </slot>
           </div>
@@ -173,23 +176,24 @@
             <RightArrowIcon />
           </slot>
         </button>
-      </div> <!-- .vib-container -->
+      </div>
+      <!-- .vib-container -->
     </transition>
   </div>
 </template>
 
 <script setup>
-import { ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
-import LeftArrowIcon from './LeftArrowIcon.vue'
-import RightArrowIcon from './RightArrowIcon.vue'
-import CloseIcon from './CloseIcon.vue'
-import VideoIcon from './VideoIcon.vue'
+import { ref, watch, onMounted, onBeforeUnmount, nextTick } from "vue";
+import LeftArrowIcon from "./LeftArrowIcon.vue";
+import RightArrowIcon from "./RightArrowIcon.vue";
+import CloseIcon from "./CloseIcon.vue";
+import VideoIcon from "./VideoIcon.vue";
 
-import { useNavigation } from '../composables/useNavigation.js'
-import { useUIControls } from '../composables/useUIControls.js'
-import { useTouchSwipe } from '../composables/useTouchSwipe.js'
-import { useYouTube } from '../composables/useYouTube.js'
-import { useLightboxLifecycle } from '../composables/useLightboxLifecycle.js'
+import { useNavigation } from "../composables/useNavigation.js";
+import { useUIControls } from "../composables/useUIControls.js";
+import { useTouchSwipe } from "../composables/useTouchSwipe.js";
+import { useYouTube } from "../composables/useYouTube.js";
+import { useLightboxLifecycle } from "../composables/useLightboxLifecycle.js";
 
 const props = defineProps({
   media: {
@@ -254,33 +258,33 @@ const props = defineProps({
 
   closeText: {
     type: String,
-    default: 'Close (Esc)',
+    default: "Close (Esc)",
   },
 
   previousText: {
     type: String,
-    default: 'Previous',
+    default: "Previous",
   },
 
   nextText: {
     type: String,
-    default: 'Next',
+    default: "Next",
   },
-})
+});
 
 const emit = defineEmits([
-  'onImageChanged',
-  'onLoad',
-  'onLastIndex',
-  'onFirstIndex',
-  'onStartIndex',
-  'onOpened',
-  'onClosed',
-])
+  "onImageChanged",
+  "onLoad",
+  "onLastIndex",
+  "onFirstIndex",
+  "onStartIndex",
+  "onOpened",
+  "onClosed",
+]);
 
 // Template refs
-const container = ref(null)
-const video = ref(null)
+const container = ref(null);
+const video = ref(null);
 
 // --- Composables (order matters for dependencies) ---
 
@@ -296,16 +300,19 @@ const {
   enableImageTransition: navEnableImageTransition,
   disableImageTransition,
   preloadAdjacentImages,
-} = useNavigation(props)
+} = useNavigation(props);
 
 const {
   controlsHidden,
   interfaceHovered,
   handleMouseActivity,
   clearInteraction,
-} = useUIControls(props)
+} = useUIControls(props);
 
-const { handleTouchStart, handleTouchEnd } = useTouchSwipe(nextImage, previousImage)
+const { handleTouchStart, handleTouchEnd } = useTouchSwipe(
+  nextImage,
+  previousImage,
+);
 
 const {
   visitedYoutubeIndices,
@@ -313,43 +320,43 @@ const {
   pauseYouTubeVideo,
   markVisited,
   cleanupYouTubePlayers,
-} = useYouTube(props, select)
+} = useYouTube(props, select);
 
 // Keyboard handler — defined here because it calls across composable boundaries
 function addKeyEvent(event) {
   switch (event.key) {
-    case 'ArrowLeft':
-      previousImage()
-      break
-    case 'ArrowRight':
-      nextImage()
-      break
-    case 'Escape':
-      closeLightBox()
-      break
+    case "ArrowLeft":
+      previousImage();
+      break;
+    case "ArrowRight":
+      nextImage();
+      break;
+    case "Escape":
+      closeLightBox();
+      break;
   }
 }
 
-const {
-  lightBoxShown,
-  closeLightBox,
-  onToggleLightBox,
-} = useLightboxLifecycle(
-  props, emit, video,
-  pauseYouTubeVideo, preloadAdjacentImages, addKeyEvent
-)
+const { lightBoxShown, closeLightBox, onToggleLightBox } = useLightboxLifecycle(
+  props,
+  emit,
+  video,
+  pauseYouTubeVideo,
+  preloadAdjacentImages,
+  addKeyEvent,
+);
 
 // Wrapped showImage — adds cross-composable side effects
 function showImage(index) {
-  navShowImage(index)
-  controlsHidden.value = false
-  lightBoxShown.value = true
+  navShowImage(index);
+  controlsHidden.value = false;
+  lightBoxShown.value = true;
 }
 
 // Wrapped enableImageTransition — triggers mouse activity first
 function enableImageTransition() {
-  handleMouseActivity()
-  navEnableImageTransition()
+  handleMouseActivity();
+  navEnableImageTransition();
 }
 
 // --- Watchers ---
@@ -357,71 +364,74 @@ function enableImageTransition() {
 watch(lightBoxShown, (value) => {
   // istanbul ignore else
   if (document != null) {
-    onToggleLightBox(value)
+    onToggleLightBox(value);
   }
-})
+});
 
 watch(select, (newVal, oldVal) => {
-  emit('onImageChanged', select.value)
+  emit("onImageChanged", select.value);
 
   if (select.value >= props.media.length - props.lengthToLoadMore - 1)
-    emit('onLoad')
+    emit("onLoad");
 
-  if (select.value === props.media.length - 1)
-    emit('onLastIndex')
+  if (select.value === props.media.length - 1) emit("onLastIndex");
 
-  if (select.value === 0)
-    emit('onFirstIndex')
+  if (select.value === 0) emit("onFirstIndex");
 
-  if (select.value === props.startAt)
-    emit('onStartIndex')
+  if (select.value === props.startAt) emit("onStartIndex");
 
-  preloadAdjacentImages()
+  preloadAdjacentImages();
 
   // Pause the YouTube video we are navigating away from
-  if (props.media[oldVal] && props.media[oldVal].type === 'youtube') {
-    pauseYouTubeVideo(oldVal)
+  if (props.media[oldVal] && props.media[oldVal].type === "youtube") {
+    pauseYouTubeVideo(oldVal);
   }
 
   // Initialize YouTube player when switching to a YouTube video
-  if (props.media[select.value] && props.media[select.value].type === 'youtube') {
-    markVisited(select.value)
+  if (
+    props.media[select.value] &&
+    props.media[select.value].type === "youtube"
+  ) {
+    markVisited(select.value);
     nextTick(() => {
-      initYouTubePlayer(select.value)
-    })
+      initYouTubePlayer(select.value);
+    });
   }
-})
+});
 
 // --- Lifecycle ---
 
-let timer = null
+let timer = null;
 
 onMounted(() => {
   if (props.autoPlay) {
-    timer = setInterval(nextImage, props.autoPlayTime)
+    timer = setInterval(nextImage, props.autoPlayTime);
   }
 
-  onToggleLightBox(lightBoxShown.value)
+  onToggleLightBox(lightBoxShown.value);
 
   // Initialize YouTube player if initial media is a YouTube video
-  if (props.media[select.value] && props.media[select.value].type === 'youtube') {
-    markVisited(select.value)
+  if (
+    props.media[select.value] &&
+    props.media[select.value].type === "youtube"
+  ) {
+    markVisited(select.value);
     nextTick(() => {
-      initYouTubePlayer(select.value)
-    })
+      initYouTubePlayer(select.value);
+    });
   }
-})
+});
 
 onBeforeUnmount(() => {
-  document.removeEventListener('keydown', addKeyEvent)
+  document.removeEventListener("keydown", addKeyEvent);
 
   if (props.autoPlay) {
-    clearInterval(timer)
+    clearInterval(timer);
   }
 
-  cleanupYouTubePlayers()
-  clearInteraction()
-})
+  cleanupYouTubePlayers();
+  clearInteraction();
+});
 
 // Expose for external callers (e.g. this.$refs.lightbox.showImage(index))
 defineExpose({
@@ -431,8 +441,7 @@ defineExpose({
   handleMouseActivity,
   preloadAdjacentImages,
   imageTransitionName,
-})
+});
 </script>
 
-<style src="./style.css">
-</style>
+<style src="./style.css"></style>

--- a/src/components/LightBox.vue
+++ b/src/components/LightBox.vue
@@ -17,7 +17,10 @@
         @touchstart="handleTouchStart"
         @touchend="handleTouchEnd"
       >
-        <div class="vib-content" @click.stop>
+        <div
+          class="vib-content"
+          @click.stop
+        >
           <transition :name="imageTransitionName">
             <div
               v-if="
@@ -31,7 +34,7 @@
                 :srcset="currentMedia.srcset || ''"
                 class="vib-image"
                 :alt="currentMedia.caption"
-              />
+              >
               <div class="vib-image-overlay">
                 <slot
                   name="imageOverlay"
@@ -54,14 +57,17 @@
                 :key="source.src"
                 :src="source.src"
                 :type="source.type"
-              />
+              >
             </video>
           </transition>
         </div>
         <!-- .vib-content -->
 
         <!-- Persistent YouTube iframes - outside transition to preserve playback state -->
-        <template v-for="(item, index) in media" :key="'youtube-' + index">
+        <template
+          v-for="(item, index) in media"
+          :key="'youtube-' + index"
+        >
           <transition :name="imageTransitionName">
             <div
               v-if="item.type === 'youtube' && visitedYoutubeIndices.has(index)"
@@ -75,8 +81,8 @@
                   :id="'youtube-player-' + index"
                   :src="
                     'https://www.youtube.com/embed/' +
-                    item.id +
-                    '?enablejsapi=1&showinfo=0'
+                      item.id +
+                      '?enablejsapi=1&showinfo=0'
                   "
                   width="560"
                   height="315"
@@ -122,12 +128,22 @@
           @mouseover="interfaceHovered = true"
           @mouseleave="interfaceHovered = false"
         >
-          <slot name="customCaption" :current-media="currentMedia">
-            <div v-show="showCaption" v-html="currentMedia.caption" />
+          <slot
+            name="customCaption"
+            :current-media="currentMedia"
+          >
+            <div
+              v-show="showCaption"
+              v-html="currentMedia.caption"
+            />
           </slot>
 
           <div class="vib-footer-count">
-            <slot name="footer" :current="select + 1" :total="media.length">
+            <slot
+              name="footer"
+              :current="select + 1"
+              :total="media.length"
+            >
               {{ select + 1 }} / {{ media.length }}
             </slot>
           </div>

--- a/src/components/style.css
+++ b/src/components/style.css
@@ -45,14 +45,25 @@
   height: 100dvh;
 }
 
+.vib-image-container {
+  position: relative;
+  display: inline-block;
+}
+
 .vib-image {
   cursor: pointer;
   max-height: calc(100vh);
   display: block;
   height: auto;
   margin: 0 auto;
-  max-width: 100%;
+  max-width: 100vw;
   user-select: none;
+}
+
+.vib-image-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
 }
 
 .vib-thumbnail-wrapper {


### PR DESCRIPTION
## Summary
- Wraps the displayed image in a shrink-to-fit `.vib-image-container` and exposes a per-slide `imageOverlay` slot (`currentMedia`, `index`) positioned exactly over the rendered image box.
- Image-type media only; the overlay layer is `pointer-events: none` so it never interferes with navigation.
- Enables consumers to draw annotations (arrows, highlight boxes) over a photo without forking rendering logic.
- Bumps package version 1.1.2 → 1.2.0.

## Test plan
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 145/145 passing
- [x] README updated with `imageOverlay` slot usage example