### PR TITLE
Update CI Node matrix: drop EOL 20.x, add 24.x and 26.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x, 26.x]
 
     steps:
       - name: Checkout code
@@ -27,5 +27,5 @@ jobs:
       - name: Run the tests
         run: npm run test:coverage
       - name: Upload coverage report to Codecov
-        if: matrix.node-version == '22.x'
+        if: matrix.node-version == '24.x'
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
Drops Node 20.x from the build matrix (end-of-life since April 2026) and adds 24.x (Active LTS) and 26.x (Current, becomes LTS in October 2026). The Codecov upload now runs on the 24.x job.

This unblocks the jsdom 30 update (#477), which requires Node `^22.22.2 || ^24.15.0 || >=26` and fails on the Node 20.x job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)